### PR TITLE
BZ-1870373: [WIP] Ingress Operator reports available when DNS fails

### DIFF
--- a/pkg/operator/controller/ingress/status.go
+++ b/pkg/operator/controller/ingress/status.go
@@ -30,6 +30,16 @@ import (
 // clock is to enable unit testing
 var clock utilclock.Clock = utilclock.RealClock{}
 
+// expectedCondition contains a condition that is expected to be checked when
+// determining Available or Degraded status of the ingress controller
+type expectedCondition struct {
+	condition        string
+	status           operatorv1.ConditionStatus
+	ifConditionsTrue []string // ifConditionsTrue is a list of dependent conditions that should be be true as well
+	gracePeriod      time.Duration
+	mustHave         bool // mustHave determines whether this expectedCondition must be there
+}
+
 // syncIngressControllerStatus computes the current status of ic and
 // updates status upon any changes since last sync.
 func (r *reconciler) syncIngressControllerStatus(ic *operatorv1.IngressController, deployment *appsv1.Deployment, pods []corev1.Pod, service *corev1.Service, operandEvents []corev1.Event, wildcardRecord *iov1.DNSRecord, dnsConfig *configv1.DNS) error {
@@ -45,12 +55,12 @@ func (r *reconciler) syncIngressControllerStatus(ic *operatorv1.IngressControlle
 	updated.Status.Selector = selector.String()
 	updated.Status.TLSProfile = computeIngressTLSProfile(ic.Status.TLSProfile, deployment)
 	updated.Status.Conditions = mergeConditions(updated.Status.Conditions, computeDeploymentPodsScheduledCondition(deployment, pods))
-	updated.Status.Conditions = mergeConditions(updated.Status.Conditions, computeIngressAvailableCondition(deployment))
 	updated.Status.Conditions = mergeConditions(updated.Status.Conditions, computeDeploymentAvailableCondition(deployment))
 	updated.Status.Conditions = mergeConditions(updated.Status.Conditions, computeDeploymentReplicasMinAvailableCondition(deployment))
 	updated.Status.Conditions = mergeConditions(updated.Status.Conditions, computeDeploymentReplicasAllAvailableCondition(deployment))
 	updated.Status.Conditions = mergeConditions(updated.Status.Conditions, computeLoadBalancerStatus(ic, service, operandEvents)...)
 	updated.Status.Conditions = mergeConditions(updated.Status.Conditions, computeDNSStatus(ic, wildcardRecord, dnsConfig)...)
+	updated.Status.Conditions = mergeConditions(updated.Status.Conditions, computeIngressAvailableCondition(updated.Status.Conditions)...)
 	degradedCondition, err := computeIngressDegradedCondition(updated.Status.Conditions)
 	errs = append(errs, err)
 	updated.Status.Conditions = mergeConditions(updated.Status.Conditions, degradedCondition)
@@ -171,35 +181,109 @@ func computeDeploymentPodsScheduledCondition(deployment *appsv1.Deployment, pods
 }
 
 // computeIngressAvailableCondition computes the ingress controller's current Available status state
-// by inspecting the Available condition of deployment. The ingresscontroller is only available if
-// the deployment is also available.
-func computeIngressAvailableCondition(deployment *appsv1.Deployment) operatorv1.OperatorCondition {
-	for _, cond := range deployment.Status.Conditions {
-		if cond.Type != appsv1.DeploymentAvailable {
-			continue
-		}
-		switch cond.Status {
-		case corev1.ConditionTrue:
-			return operatorv1.OperatorCondition{
-				Type:   operatorv1.IngressControllerAvailableConditionType,
-				Status: operatorv1.ConditionTrue,
-			}
-		case corev1.ConditionFalse:
-			return operatorv1.OperatorCondition{
+// by inspecting the following:
+// 1) the Available condition of deployment
+// 2) the DNSReady condition
+// 3) the LoadBalancerReady condition
+// The ingresscontroller is judged Available only if all 3 conditions are true
+func computeIngressAvailableCondition(conditions []operatorv1.OperatorCondition) []operatorv1.OperatorCondition {
+	conditionsMap := make(map[string]*operatorv1.OperatorCondition)
+	for i := range conditions {
+		conditionsMap[conditions[i].Type] = &conditions[i]
+	}
+	expected := []expectedCondition{
+		{
+			condition: string(appsv1.DeploymentAvailable),
+			status:    operatorv1.ConditionTrue,
+			mustHave:  true,
+		},
+		{
+			condition: operatorv1.DNSReadyIngressConditionType,
+			status:    operatorv1.ConditionTrue,
+			ifConditionsTrue: []string{
+				operatorv1.LoadBalancerManagedIngressConditionType,
+				operatorv1.LoadBalancerReadyIngressConditionType,
+				operatorv1.DNSManagedIngressConditionType,
+			},
+			gracePeriod: time.Second * 30,
+			mustHave:    true,
+		},
+		{
+			condition:        operatorv1.LoadBalancerReadyIngressConditionType,
+			status:           operatorv1.ConditionTrue,
+			ifConditionsTrue: []string{operatorv1.LoadBalancerManagedIngressConditionType},
+			gracePeriod:      time.Second * 90,
+			mustHave:         true,
+		},
+	}
+	_, unavailableConditions := checkAnnotatedConditions(expected, conditionsMap)
+
+	// TODO - check with team - do we want to use a grace period when checking Available?
+
+	if len(unavailableConditions) != 0 {
+		degraded := formatConditions(unavailableConditions)
+		return []operatorv1.OperatorCondition{
+			{
 				Type:    operatorv1.IngressControllerAvailableConditionType,
 				Status:  operatorv1.ConditionFalse,
-				Reason:  cond.Reason,
-				Message: "The deployment is unavailable: " + cond.Message,
-			}
+				Reason:  "IngressControllerUnavailable",
+				Message: "One or more status conditions indicate unavailable: " + degraded,
+			},
+		}
+	} else {
+		return []operatorv1.OperatorCondition{
+			{
+				Type:   operatorv1.IngressControllerAvailableConditionType,
+				Status: operatorv1.ConditionTrue,
+			},
 		}
 	}
+}
 
-	return operatorv1.OperatorCondition{
-		Type:    operatorv1.IngressControllerAvailableConditionType,
-		Status:  operatorv1.ConditionFalse,
-		Reason:  "DeploymentAvailabilityUnknown",
-		Message: "The deployment's Available condition couldn't be interpreted",
+func checkAnnotatedConditions(expecteds []expectedCondition, conditionsMap map[string]*operatorv1.OperatorCondition) ([]*operatorv1.OperatorCondition, []*operatorv1.OperatorCondition) {
+	var graceConditions, degradedConditions []*operatorv1.OperatorCondition
+	now := clock.Now()
+	// Keep checking conditions every minute while degraded.
+	requeueAfter := time.Minute
+	for _, expected := range expecteds {
+		condition, haveCondition := conditionsMap[expected.condition]
+		if !haveCondition {
+			if expected.mustHave {
+				degradedConditions = append(degradedConditions, &operatorv1.OperatorCondition{Type: expected.condition, Status: operatorv1.ConditionUnknown})
+			}
+			continue
+		}
+		if condition.Status == expected.status {
+			continue
+		}
+		failedPredicates := false
+		for _, ifCond := range expected.ifConditionsTrue {
+			predicate, havePredicate := conditionsMap[ifCond]
+			if !havePredicate || predicate.Status != operatorv1.ConditionTrue {
+				failedPredicates = true
+				break
+			}
+		}
+		if failedPredicates {
+			continue
+		}
+		if expected.gracePeriod != 0 {
+			t1 := now.Add(-expected.gracePeriod)
+			t2 := condition.LastTransitionTime
+			if t2.After(t1) {
+				d := t2.Sub(t1)
+				if len(graceConditions) == 0 || d < requeueAfter {
+					// Recompute status conditions again
+					// after the grace period has elapsed.
+					requeueAfter = d
+				}
+				graceConditions = append(graceConditions, condition)
+				continue
+			}
+		}
+		degradedConditions = append(degradedConditions, condition)
 	}
+	return graceConditions, degradedConditions
 }
 
 // computeDeploymentAvailableCondition computes the ingresscontroller's
@@ -344,12 +428,7 @@ func computeIngressDegradedCondition(conditions []operatorv1.OperatorCondition) 
 		conditionsMap[conditions[i].Type] = &conditions[i]
 	}
 
-	expectedConditions := []struct {
-		condition        string
-		status           operatorv1.ConditionStatus
-		ifConditionsTrue []string
-		gracePeriod      time.Duration
-	}{
+	expected := []expectedCondition{
 		{
 			condition: IngressControllerAdmittedConditionType,
 			status:    operatorv1.ConditionTrue,
@@ -392,54 +471,13 @@ func computeIngressDegradedCondition(conditions []operatorv1.OperatorCondition) 
 		},
 	}
 
-	var graceConditions, degradedConditions []*operatorv1.OperatorCondition
-	now := clock.Now()
-	for _, expected := range expectedConditions {
-		condition, haveCondition := conditionsMap[expected.condition]
-		if !haveCondition {
-			continue
-		}
-		if condition.Status == expected.status {
-			continue
-		}
-		failedPredicates := false
-		for _, ifCond := range expected.ifConditionsTrue {
-			predicate, havePredicate := conditionsMap[ifCond]
-			if !havePredicate || predicate.Status != operatorv1.ConditionTrue {
-				failedPredicates = true
-				break
-			}
-		}
-		if failedPredicates {
-			continue
-		}
-		if expected.gracePeriod != 0 {
-			t1 := now.Add(-expected.gracePeriod)
-			t2 := condition.LastTransitionTime
-			if t2.After(t1) {
-				d := t2.Sub(t1)
-				if len(graceConditions) == 0 || d < requeueAfter {
-					// Recompute status conditions again
-					// after the grace period has elapsed.
-					requeueAfter = d
-				}
-				graceConditions = append(graceConditions, condition)
-				continue
-			}
-		}
-		degradedConditions = append(degradedConditions, condition)
-	}
+	graceConditions, degradedConditions := checkAnnotatedConditions(expected, conditionsMap)
 
 	if len(degradedConditions) != 0 {
 		// Keep checking conditions every minute while degraded.
 		requeueAfter = time.Minute
 
-		var degraded string
-		for _, cond := range degradedConditions {
-			degraded = degraded + fmt.Sprintf(", %s=%s (%s: %s)", cond.Type, cond.Status, cond.Reason, cond.Message)
-		}
-		degraded = degraded[2:]
-
+		degraded := formatConditions(degradedConditions)
 		condition := operatorv1.OperatorCondition{
 			Type:    operatorv1.OperatorStatusTypeDegraded,
 			Status:  operatorv1.ConditionTrue,
@@ -467,6 +505,18 @@ func computeIngressDegradedCondition(conditions []operatorv1.OperatorCondition) 
 	}
 
 	return condition, err
+}
+
+func formatConditions(conditions []*operatorv1.OperatorCondition) string {
+	var formatted string
+	if len(conditions) == 0 {
+		return ""
+	}
+	for _, cond := range conditions {
+		formatted = formatted + fmt.Sprintf(", %s=%s (%s: %s)", cond.Type, cond.Status, cond.Reason, cond.Message)
+	}
+	formatted = formatted[2:]
+	return formatted
 }
 
 // ingressStatusesEqual compares two IngressControllerStatus values.  Returns true


### PR DESCRIPTION
BZ-1870373: Ingress Operator reports available when DNS fails to provision

- Check DNSReady and LoadBalancerReady when determining Availability in computeIngressAvailableCondition
- Call computeIngressAvailableCondition after computing other conditions in syncIngressControllerStatus
- Change unit tests for computeIngressAvailableCondition
- Refactor the checks for conditions into checkAnnotatedConditions, to share between computeIngressAvailable and computeIngressDegraded